### PR TITLE
Fix mongodb cleanup ordering

### DIFF
--- a/txfixtures/mongodb.py
+++ b/txfixtures/mongodb.py
@@ -33,12 +33,13 @@ class MongoDB(Service):
         self.addDataDir()
         super(MongoDB, self)._setUp()
         uri = "mongodb://localhost:%d" % self.port
-        self.client = pymongo.MongoClient(uri, **self.clientKwargs)
-        self.addCleanup(self.client.close)
 
         # XXX Workaround pymongo leaving threads around.
         if int(pymongo.version.split(".")[0]) >= 3:
             self.addCleanup(pymongo.periodic_executor._shutdown_executors)
+
+        self.client = pymongo.MongoClient(uri, **self.clientKwargs)
+        self.addCleanup(self.client.close)
 
     def _extraArgs(self):
         return [


### PR DESCRIPTION
Cleanups are run in reverse order, so register the executor shutdown
first so that it's run last.  This makes tests a little more reliable.