### PR TITLE
WIP: Adapt package to Twisted 23.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fixtures
 testtools
-twisted<=22.10
+twisted==23.8
 psutil

--- a/txfixtures/reactor.py
+++ b/txfixtures/reactor.py
@@ -7,7 +7,11 @@ from six.moves.queue import Queue
 
 from fixtures import Fixture
 
-from twisted.internet.posixbase import _SIGCHLDWaker
+# _SIGCHLDWaker was moved in Twisted version 23.8
+try:
+    from twisted.internet.posixbase import _SIGCHLDWaker
+except ImportError:
+    from twisted.internet._signals import _SIGCHLDWaker
 from twisted.internet.epollreactor import EPollReactor
 
 from txfixtures._twisted.threading import (
@@ -107,7 +111,7 @@ class Reactor(Fixture):
         # reactor thread as it's not thread-safe. The SIGCHLD waker will
         # react to SIGCHLD signals by writing to a dummy pipe, which will
         # wake up epoll() calls.
-        self.reactor._childWaker = _SIGCHLDWaker(self.reactor)
+        self.reactor._childWaker = _SIGCHLDWaker()
         self.call(1, self._addSIGCHLDWaker)
 
         # Install the actual signal hander (this needs to happen in the main

--- a/txfixtures/tests/test_reactor.py
+++ b/txfixtures/tests/test_reactor.py
@@ -5,7 +5,14 @@ from fixtures import FakeLogger
 from systemfixtures import FakeThreads
 
 from twisted.internet.defer import succeed
-from twisted.internet.posixbase import _SIGCHLDWaker
+
+# _SIGCHLDWaker was moved in Twisted version 23.8
+try:
+    from twisted.internet.posixbase import _SIGCHLDWaker
+except ImportError:
+    from twisted.internet._signals import _SIGCHLDWaker
+
+from twisted.internet.epollreactor import EPollReactor
 
 from txfixtures._twisted.testing import ThreadedMemoryReactorClock
 


### PR DESCRIPTION
Twisted 23.8 has both moved _SIGCHLDWaker to another module, and has changed its signature.

A couple of tests are now failing, which either means, we need to update the tests or update the code for txfixtures.